### PR TITLE
Allow escape character backslash in date format

### DIFF
--- a/src/Converter.php
+++ b/src/Converter.php
@@ -15,11 +15,25 @@ class Converter
     {
         $format = '';
 
+        $escape = false;
         foreach (str_split($this->format) as $token) {
+            if ($escape) {
+                $format .= "[{$token}]";
+                $escape = false;
+                continue;
+            }
+
+            if ($token === '\\') {
+                $escape = true;
+                continue;
+            }
+
             $format .= array_key_exists($token, DATE_FORMAT_STANDARDS) ?
                 DATE_FORMAT_STANDARDS[$token][$standard] :
                 $token;
         }
+
+        $format = str_replace('][', '', $format);
 
         return $format;
     }

--- a/src/Converter.php
+++ b/src/Converter.php
@@ -15,25 +15,11 @@ class Converter
     {
         $format = '';
 
-        $escape = false;
         foreach (str_split($this->format) as $token) {
-            if ($escape) {
-                $format .= "[{$token}]";
-                $escape = false;
-                continue;
-            }
-
-            if ($token === '\\') {
-                $escape = true;
-                continue;
-            }
-
             $format .= array_key_exists($token, DATE_FORMAT_STANDARDS) ?
                 DATE_FORMAT_STANDARDS[$token][$standard] :
                 $token;
         }
-
-        $format = str_replace('][', '', $format);
 
         return $format;
     }

--- a/src/Converter.php
+++ b/src/Converter.php
@@ -16,15 +16,19 @@ class Converter
         $format = '';
 
         $escape = false;
+        
         foreach (str_split($this->format) as $token) {
             if ($token === '[') {
                 $escape = true;
             }
+            
             if ($escape) {
                 if ($token === ']') {
                     $escape = false;
                 }
+                
                 $format .= $token;
+                
                 continue;
             }
 

--- a/src/Converter.php
+++ b/src/Converter.php
@@ -15,7 +15,19 @@ class Converter
     {
         $format = '';
 
+        $escape = false;
         foreach (str_split($this->format) as $token) {
+            if ($token === '[') {
+                $escape = true;
+            }
+            if ($escape) {
+                if ($token === ']') {
+                    $escape = false;
+                }
+                $format .= $token;
+                continue;
+            }
+
             $format .= array_key_exists($token, DATE_FORMAT_STANDARDS) ?
                 DATE_FORMAT_STANDARDS[$token][$standard] :
                 $token;


### PR DESCRIPTION
This PR  converts escape characters to be compatible with **day.js** and **moment.js**, so you can write characters you don't want to be converted between brackets e.g.:

`d [de] M`

will be converted to

`DD [de] MMM`